### PR TITLE
Empty base class optimization enabled on Visual Studio >= 2017.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -293,3 +293,7 @@ TEST_CASE("Named arguments")
     REQUIRE(fullName == "JamesBond");
 }
 
+TEST_CASE("Empty base class optimization")
+{
+    REQUIRE(sizeof(Meter) == sizeof(double));
+}

--- a/named_type_impl.hpp
+++ b/named_type_impl.hpp
@@ -3,6 +3,13 @@
 
 #include <type_traits>
 
+// Enable empty base class optimization with multiple inheritance on Visual Studio.
+#if defined(_MSC_VER) && _MSC_VER >= 1910
+#  define FLUENT_EBCO __declspec(empty_bases)
+#else
+#  define FLUENT_EBCO
+#endif
+
 namespace fluent
 {
     
@@ -10,7 +17,7 @@ template<typename T>
 using IsNotReference = typename std::enable_if<!std::is_reference<T>::value, void>::type;
 
 template <typename T, typename Parameter, template<typename> class... Skills>
-class NamedType : public Skills<NamedType<T, Parameter, Skills...>>...
+class FLUENT_EBCO NamedType : public Skills<NamedType<T, Parameter, Skills...>>...
 {
 public:
     using UnderlyingType = T;


### PR DESCRIPTION
Multiple inheritance inhibits EBCO on Visual Studio. See https://blogs.msdn.microsoft.com/vcblog/2016/03/30/optimizing-the-layout-of-empty-base-classes-in-vs2015-update-2-3/ for more details.

I also added a test case to see that adding more than one skill has no memory overhead.