### PR TITLE
Add missing include

### DIFF
--- a/named_type_impl.hpp
+++ b/named_type_impl.hpp
@@ -2,6 +2,7 @@
 #define named_type_impl_h
 
 #include <type_traits>
+#include <utility>
 
 // Enable empty base class optimization with multiple inheritance on Visual Studio.
 #if defined(_MSC_VER) && _MSC_VER >= 1910


### PR DESCRIPTION
std::move and std::forward are defined in utility