### PR TITLE
get() const should return a reference to const rather than a const reference

### DIFF
--- a/named_type_impl.hpp
+++ b/named_type_impl.hpp
@@ -29,7 +29,7 @@ public:
     
     // get
     constexpr T& get() { return value_; }
-    constexpr T const& get() const {return value_; }
+    constexpr std::remove_reference_t<T> const& get() const {return value_; }
 
     // conversions
     using ref = NamedType<T&, Parameter, Skills...>;


### PR DESCRIPTION
This fixes the issue that NamedType exhibits the issue you described [here](https://www.fluentcpp.com/2018/07/13/the-incredible-const-reference-that-isnt-const/url) where `get()` on `const NamedType<T&, Tag>` is mutable rather than const.