### PR TITLE
Add feature to pass named argument in any order

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Basic usage")
 
 using NameRef = fluent::NamedType<std::string&, struct NameRefParameter>;
 
-void changeValue(const NameRef name)
+void changeValue(NameRef name)
 {
     name.get() = "value2";
 }

--- a/main.cpp
+++ b/main.cpp
@@ -300,6 +300,25 @@ TEST_CASE("Named arguments")
     REQUIRE(fullName == "JamesBond");
 }
 
+TEST_CASE("Named arguments in any order")
+{
+    using FirstName = fluent::NamedType<std::string, struct FirstNameTag>;
+    using LastName = fluent::NamedType<std::string, struct LastNameTag>;
+    static const FirstName::argument firstName;
+    static const LastName::argument lastName;
+
+    auto getFullName = fluent::make_named_arg_function<FirstName, LastName>([](FirstName const& firstName, LastName const& lastName)
+    {
+        return firstName.get() + lastName.get();
+    });
+
+    auto fullName = getFullName(lastName = "Bond", firstName = "James");
+    REQUIRE(fullName == "JamesBond");
+
+    auto otherFullName = getFullName(firstName = "James", lastName = "Bond");
+    REQUIRE(otherFullName == "JamesBond");
+}
+
 TEST_CASE("Empty base class optimization")
 {
     REQUIRE(sizeof(Meter) == sizeof(double));

--- a/named_type_impl.hpp
+++ b/named_type_impl.hpp
@@ -62,6 +62,26 @@ constexpr StrongType<T> make_named(T const& value)
 {
     return StrongType<T>(value);
 }
+
+namespace details {
+template <class F, class... Ts>
+struct AnyOrderCallable{
+    F f;
+    template <class... Us>
+    auto operator()(Us&&...args) const
+    {
+        static_assert(sizeof...(Ts) == sizeof...(Us), "Passing wrong number of arguments");
+        auto x = std::make_tuple(std::forward<Us>(args)...);
+        return f(std::move(std::get<Ts>(x))...);
+    }
+};
+} //namespace details
+
+template <class... Args, class F>
+auto make_named_arg_function(F&& f)
+{
+    return details::AnyOrderCallable<F, Args...>{std::forward<F>(f)};
+}
     
 } // namespace fluent
 


### PR DESCRIPTION
I have an idea for named argument feature from your blog here https://www.fluentcpp.com/2018/12/14/named-arguments-cpp/

The interface will look like this:
```cpp
auto getFullNameImpl(FirstName const& firstName, LastName const& lastName);
const auto getFullName = fluent::make_named_arg_function<FirstName, LastName>(getFullNameImpl);
auto fullName = getFullName(lastName = "Bond", firstName = "James");
auto otherFullName = getFullName(firstName = "James", lastName = "Bond");
````