### PR TITLE
Include unary operators in Subtractable/Addable skills

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Basic usage")
 
 using NameRef = fluent::NamedType<std::string&, struct NameRefParameter>;
 
-void changeValue(const NameRef name)
+void changeValue(NameRef name)
 {
     name.get() = "value2";
 }

--- a/main.cpp
+++ b/main.cpp
@@ -102,6 +102,7 @@ TEST_CASE("Addable")
     AddableType s1(12);
     AddableType s2(10);
     REQUIRE((s1 + s2).get() == 22);
+    REQUIRE((+s1).get() == 12);
 }
 
 TEST_CASE("Subtractable")
@@ -110,6 +111,7 @@ TEST_CASE("Subtractable")
     SubtractableType s1(12);
     SubtractableType s2(10);
     REQUIRE((s1 - s2).get() == 2);
+    REQUIRE((-s1).get() == -12);
 }
 
 TEST_CASE("Multiplicable")

--- a/underlying_functionalities.hpp
+++ b/underlying_functionalities.hpp
@@ -27,12 +27,14 @@ template <typename T>
 struct Addable : crtp<T, Addable>
 {
     T operator+(T const& other) const { return T(this->underlying().get() + other.get()); }
+    T operator+() const { return T(+this->underlying().get()); }
 };
 
 template <typename T>
 struct Subtractable : crtp<T, Subtractable>
 {
     T operator-(T const& other) const { return T(this->underlying().get() - other.get()); }
+    T operator-() const { return T(-this->underlying().get()); }
 };
     
 template <typename T>


### PR DESCRIPTION
Unary minus is needed to make user defined literals work nicely, since
the minus is not a part of the literal, but rather applied as a unary
operator afterwards. For instance:

```cpp
using DegreesCelcius =
    fluent::NamedType<double, struct DegreesCelciusTag, fluent::Subtractable>;

DegreesCelcius operator"" _C(long double degreesCelcius)
{
    return DegreesCelcius(degreesCelcius);
}

DegreesCelcius minimumValue{-45._C};
```

The last line will first construct a `DegreesCelcius{45.}`, and then apply
`operator-` to it.

I also included unary plus in `Addable` for symmetry, even if it's a lot
less useful than unary minus.

(The compilation error in `main.cpp` is also fixed in #30, but I included it here as well so it's possible to run tests.)