### PR TITLE
Make version number accessible in code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(${PROJECT_NAME} INTERFACE
 	"include/NamedType/named_type.hpp"
 	"include/NamedType/named_type_impl.hpp"
 	"include/NamedType/underlying_functionalities.hpp"
+	"include/NamedType/version.hpp"
 )
 
 set(ENABLE_TEST ON CACHE BOOL "Enable test")

--- a/include/NamedType/named_type.hpp
+++ b/include/NamedType/named_type.hpp
@@ -3,5 +3,6 @@
 
 #include "named_type_impl.hpp"
 #include "underlying_functionalities.hpp"
+#include "version.hpp"
 
 #endif

--- a/include/NamedType/version.hpp
+++ b/include/NamedType/version.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace fluent
+{
+#define NAMED_TYPE_VERSION_MAJOR 1
+#define NAMED_TYPE_VERSION_MINOR 1
+#define NAMED_TYPE_VERSION_PATCH 0
+#define NAMED_TYPE_VERSION "1.1.0"
+} // namespace fluent

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -564,3 +564,14 @@ TEST_CASE("Arithmetic")
     a /= b;
     CHECK(a.get() == 5);
 }
+
+TEST_CASE("Version macros are defined")
+{
+    static_assert(NAMED_TYPE_VERSION_MAJOR >= 1, "");
+    static_assert(NAMED_TYPE_VERSION_MINOR >= 0, "");
+    static_assert(NAMED_TYPE_VERSION_PATCH >= 0, "");
+
+    std::stringstream ss;
+    ss << NAMED_TYPE_VERSION_MAJOR << '.' << NAMED_TYPE_VERSION_MINOR << '.' << NAMED_TYPE_VERSION_PATCH;
+    CHECK(ss.str() == NAMED_TYPE_VERSION);
+}


### PR DESCRIPTION
This is just a suggestion, feel free to decline this or let me know if you prefer doing it in another way, such as with a shell script or Python or whatever. Or simply hard coding the version number in some header file.

~~Note that this PR conflicts with #46. If that one gets accepted, I'll rebase this one on master.~~

---

We're already making versioned releases, so let's make that version
number available in code.

There are many ways to do this, such as release scripts etc. I chose a
very simple CMake solution because the project is already using CMake
and I didn't want to introduce a dependency on a new language.

Since we're not actually building releases anywhere, but just release
the source code from the repo, I had to generate the version file inside
the source tree. The person releasing will then have to commit both
CMakeLists.txt and include/NamedType/version.hpp when bumping the
version. (As well as tagging the commit, as before.)

One downside of this approach is that there is no way to detect whether
you're using the actual x.y.z release, or if you just cloned the repo
some time after x.y.z was released and the version number hasn't been
bumped yet. This could have been solved by adding a "preview" suffix or
something like that, which is removed in official releases. But I think
that would complicate this code, and the release procedure too much for
this project. And it will anyway not be a issue for users who stick to
the official releases only.