### PR TITLE
New skill Dereferencable, adding constexpr, adding [[nodiscard]], and other fixes

### DIFF
--- a/include/NamedType/crtp.hpp
+++ b/include/NamedType/crtp.hpp
@@ -7,11 +7,11 @@ namespace fluent
 template <typename T, template <typename> class crtpType>
 struct crtp
 {
-    T& underlying()
+    constexpr T& underlying()
     {
         return static_cast<T&>(*this);
     }
-    T const& underlying() const
+    constexpr T const& underlying() const
     {
         return static_cast<T const&>(*this);
     }

--- a/include/NamedType/named_type_impl.hpp
+++ b/include/NamedType/named_type_impl.hpp
@@ -5,6 +5,26 @@
 #include <type_traits>
 #include <utility>
 
+// C++17 detection
+#if defined(_MSC_VER) && (defined(_HAS_CXX17) && _HAS_CXX17)
+#    define FLUENT_CPP17_PRESENT 1
+#elif __cplusplus >= 201703L
+#    define FLUENT_CPP17_PRESENT 1
+#else
+#    define FLUENT_CPP17_PRESENT 0
+#endif
+
+// Use [[nodiscard]] if available
+#ifndef FLUENT_NODISCARD_PRESENT
+#    define FLUENT_NODISCARD_PRESENT FLUENT_CPP17_PRESENT
+#endif
+
+#if FLUENT_NODISCARD_PRESENT
+#    define FLUENT_NODISCARD [[nodiscard]]
+#else
+#    define FLUENT_NODISCARD
+#endif
+
 // Enable empty base class optimization with multiple inheritance on Visual Studio.
 #if defined(_MSC_VER) && _MSC_VER >= 1910
 #    define FLUENT_EBCO __declspec(empty_bases)
@@ -50,12 +70,12 @@ public:
     }
 
     // get
-    constexpr T& get() noexcept
+    FLUENT_NODISCARD constexpr T& get() noexcept
     {
         return value_;
     }
 
-    constexpr std::remove_reference_t<T> const& get() const noexcept
+    FLUENT_NODISCARD constexpr std::remove_reference_t<T> const& get() const noexcept
     {
         return value_;
     }

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -88,7 +88,7 @@ struct BinaryAddable : crtp<T, BinaryAddable>
     {
         return T(this->underlying().get() + other.get());
     }
-    T& operator+=(T const& other)
+    FLUENT_CONSTEXPR17 T& operator+=(T const& other)
     {
         this->underlying().get() += other.get();
         return this->underlying();
@@ -118,7 +118,7 @@ struct BinarySubtractable : crtp<T, BinarySubtractable>
     {
         return T(this->underlying().get() - other.get());
     }
-    T& operator-=(T const& other)
+    FLUENT_CONSTEXPR17 T& operator-=(T const& other)
     {
         this->underlying().get() -= other.get();
         return this->underlying();
@@ -148,7 +148,7 @@ struct Multiplicable : crtp<T, Multiplicable>
     {
         return T(this->underlying().get() * other.get());
     }
-    T& operator*=(T const& other)
+    FLUENT_CONSTEXPR17 T& operator*=(T const& other)
     {
         this->underlying().get() *= other.get();
         return this->underlying();
@@ -162,7 +162,7 @@ struct Divisible : crtp<T, Divisible>
     {
         return T(this->underlying().get() / other.get());
     }
-    T& operator/=(T const& other)
+    FLUENT_CONSTEXPR17 T& operator/=(T const& other)
     {
         this->underlying().get() /= other.get();
         return this->underlying();
@@ -176,7 +176,7 @@ struct Modulable : crtp<T, Modulable>
     {
         return T(this->underlying().get() % other.get());
     }
-    T& operator%=(T const& other)
+    FLUENT_CONSTEXPR17 T& operator%=(T const& other)
     {
         this->underlying().get() %= other.get();
         return this->underlying();
@@ -199,7 +199,7 @@ struct BitWiseAndable : crtp<T, BitWiseAndable>
     {
         return T(this->underlying().get() & other.get());
     }
-    T& operator&=(T const& other)
+    FLUENT_CONSTEXPR17 T& operator&=(T const& other)
     {
         this->underlying().get() &= other.get();
         return this->underlying();
@@ -213,7 +213,7 @@ struct BitWiseOrable : crtp<T, BitWiseOrable>
     {
         return T(this->underlying().get() | other.get());
     }
-    T& operator|=(T const& other)
+    FLUENT_CONSTEXPR17 T& operator|=(T const& other)
     {
         this->underlying().get() |= other.get();
         return this->underlying();
@@ -227,7 +227,7 @@ struct BitWiseXorable : crtp<T, BitWiseXorable>
     {
         return T(this->underlying().get() ^ other.get());
     }
-    T& operator^=(T const& other)
+    FLUENT_CONSTEXPR17 T& operator^=(T const& other)
     {
         this->underlying().get() ^= other.get();
         return this->underlying();
@@ -241,7 +241,7 @@ struct BitWiseLeftShiftable : crtp<T, BitWiseLeftShiftable>
     {
         return T(this->underlying().get() << other.get());
     }
-    T& operator<<=(T const& other)
+    FLUENT_CONSTEXPR17 T& operator<<=(T const& other)
     {
         this->underlying().get() <<= other.get();
         return this->underlying();
@@ -255,7 +255,7 @@ struct BitWiseRightShiftable : crtp<T, BitWiseRightShiftable>
     {
         return T(this->underlying().get() >> other.get());
     }
-    T& operator>>=(T const& other)
+    FLUENT_CONSTEXPR17 T& operator>>=(T const& other)
     {
         this->underlying().get() >>= other.get();
         return this->underlying();

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -376,11 +376,11 @@ struct MethodCallable;
 template <typename T, typename Parameter, template <typename> class... Skills>
 struct MethodCallable<NamedType<T, Parameter, Skills...>> : crtp<NamedType<T, Parameter, Skills...>, MethodCallable>
 {
-    constexpr std::remove_reference_t<T> const* operator->() const
+    FLUENT_CONSTEXPR17 std::remove_reference_t<T> const* operator->() const
     {
         return std::addressof(this->underlying().get());
     }
-    constexpr std::remove_reference_t<T>* operator->()
+    FLUENT_CONSTEXPR17 std::remove_reference_t<T>* operator->()
     {
         return std::addressof(this->underlying().get());
     }

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -280,7 +280,7 @@ struct Comparable : crtp<T, Comparable>
         return !(*this < other) && !(other.get() < this->underlying().get());
     }
 #else
-    friend FLUENT_NODISCARD constexpr bool operator==(Comparable<T> const& self, T const& other)
+    FLUENT_NODISCARD friend constexpr bool operator==(Comparable<T> const& self, T const& other)
     {
         return !(self < other) && !(other.get() < self.underlying().get());
     }

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -263,15 +263,6 @@ struct Comparable : crtp<T, Comparable>
     }
 };
 
-template <typename T>
-struct Printable : crtp<T, Printable>
-{
-    void print(std::ostream& os) const
-    {
-        os << this->underlying().get();
-    }
-};
-
 template <typename Destination>
 struct ImplicitlyConvertibleTo
 {
@@ -285,8 +276,20 @@ struct ImplicitlyConvertibleTo
     };
 };
 
+template <typename T>
+struct Printable : crtp<T, Printable>
+{
+    static constexpr bool is_printable = true;
+
+    void print(std::ostream& os) const
+    {
+        os << this->underlying().get();
+    }
+};
+
 template <typename T, typename Parameter, template <typename> class... Skills>
-std::ostream& operator<<(std::ostream& os, NamedType<T, Parameter, Skills...> const& object)
+typename std::enable_if<NamedType<T, Parameter, Skills...>::is_printable, std::ostream&>::type
+operator<<(std::ostream& os, NamedType<T, Parameter, Skills...> const& object)
 {
     object.print(os);
     return os;

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -306,7 +306,7 @@ struct ImplicitlyConvertibleTo
     template <typename T>
     struct templ : crtp<T, templ>
     {
-        operator Destination() const
+        constexpr operator Destination() const
         {
             return this->underlying().get();
         }

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -360,11 +360,11 @@ struct FunctionCallable;
 template <typename T, typename Parameter, template <typename> class... Skills>
 struct FunctionCallable<NamedType<T, Parameter, Skills...>> : crtp<NamedType<T, Parameter, Skills...>, FunctionCallable>
 {
-    operator T const&() const
+    constexpr operator T const&() const
     {
         return this->underlying().get();
     }
-    operator T&()
+    constexpr operator T&()
     {
         return this->underlying().get();
     }

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -8,15 +8,6 @@
 #include <iostream>
 #include <memory>
 
-// C++17 detection
-#if defined(_MSC_VER) && (defined(_HAS_CXX17) && _HAS_CXX17)
-#    define FLUENT_CPP17_PRESENT 1
-#elif __cplusplus >= 201703L
-#    define FLUENT_CPP17_PRESENT 1
-#else
-#    define FLUENT_CPP17_PRESENT 0
-#endif
-
 // C++17 constexpr additions
 #if FLUENT_CPP17_PRESENT
 #    define FLUENT_CONSTEXPR17 constexpr
@@ -84,7 +75,7 @@ struct PostDecrementable : crtp<T, PostDecrementable>
 template <typename T>
 struct BinaryAddable : crtp<T, BinaryAddable>
 {
-    constexpr T operator+(T const& other) const
+    FLUENT_NODISCARD constexpr T operator+(T const& other) const
     {
         return T(this->underlying().get() + other.get());
     }
@@ -98,7 +89,7 @@ struct BinaryAddable : crtp<T, BinaryAddable>
 template <typename T>
 struct UnaryAddable : crtp<T, UnaryAddable>
 {
-    constexpr T operator+() const
+    FLUENT_NODISCARD constexpr T operator+() const
     {
         return T(+this->underlying().get());
     }
@@ -114,7 +105,7 @@ struct Addable : BinaryAddable<T>, UnaryAddable<T>
 template <typename T>
 struct BinarySubtractable : crtp<T, BinarySubtractable>
 {
-    constexpr T operator-(T const& other) const
+    FLUENT_NODISCARD constexpr T operator-(T const& other) const
     {
         return T(this->underlying().get() - other.get());
     }
@@ -128,7 +119,7 @@ struct BinarySubtractable : crtp<T, BinarySubtractable>
 template <typename T>
 struct UnarySubtractable : crtp<T, UnarySubtractable>
 {
-    constexpr T operator-() const
+    FLUENT_NODISCARD constexpr T operator-() const
     {
         return T(-this->underlying().get());
     }
@@ -144,7 +135,7 @@ struct Subtractable : BinarySubtractable<T>, UnarySubtractable<T>
 template <typename T>
 struct Multiplicable : crtp<T, Multiplicable>
 {
-    constexpr T operator*(T const& other) const
+    FLUENT_NODISCARD constexpr T operator*(T const& other) const
     {
         return T(this->underlying().get() * other.get());
     }
@@ -158,7 +149,7 @@ struct Multiplicable : crtp<T, Multiplicable>
 template <typename T>
 struct Divisible : crtp<T, Divisible>
 {
-    constexpr T operator/(T const& other) const
+    FLUENT_NODISCARD constexpr T operator/(T const& other) const
     {
         return T(this->underlying().get() / other.get());
     }
@@ -172,7 +163,7 @@ struct Divisible : crtp<T, Divisible>
 template <typename T>
 struct Modulable : crtp<T, Modulable>
 {
-    constexpr T operator%(T const& other) const
+    FLUENT_NODISCARD constexpr T operator%(T const& other) const
     {
         return T(this->underlying().get() % other.get());
     }
@@ -186,7 +177,7 @@ struct Modulable : crtp<T, Modulable>
 template <typename T>
 struct BitWiseInvertable : crtp<T, BitWiseInvertable>
 {
-    constexpr T operator~() const
+    FLUENT_NODISCARD constexpr T operator~() const
     {
         return T(~this->underlying().get());
     }
@@ -195,7 +186,7 @@ struct BitWiseInvertable : crtp<T, BitWiseInvertable>
 template <typename T>
 struct BitWiseAndable : crtp<T, BitWiseAndable>
 {
-    constexpr T operator&(T const& other) const
+    FLUENT_NODISCARD constexpr T operator&(T const& other) const
     {
         return T(this->underlying().get() & other.get());
     }
@@ -209,7 +200,7 @@ struct BitWiseAndable : crtp<T, BitWiseAndable>
 template <typename T>
 struct BitWiseOrable : crtp<T, BitWiseOrable>
 {
-    constexpr T operator|(T const& other) const
+    FLUENT_NODISCARD constexpr T operator|(T const& other) const
     {
         return T(this->underlying().get() | other.get());
     }
@@ -223,7 +214,7 @@ struct BitWiseOrable : crtp<T, BitWiseOrable>
 template <typename T>
 struct BitWiseXorable : crtp<T, BitWiseXorable>
 {
-    constexpr T operator^(T const& other) const
+    FLUENT_NODISCARD constexpr T operator^(T const& other) const
     {
         return T(this->underlying().get() ^ other.get());
     }
@@ -237,7 +228,7 @@ struct BitWiseXorable : crtp<T, BitWiseXorable>
 template <typename T>
 struct BitWiseLeftShiftable : crtp<T, BitWiseLeftShiftable>
 {
-    constexpr T operator<<(T const& other) const
+    FLUENT_NODISCARD constexpr T operator<<(T const& other) const
     {
         return T(this->underlying().get() << other.get());
     }
@@ -251,7 +242,7 @@ struct BitWiseLeftShiftable : crtp<T, BitWiseLeftShiftable>
 template <typename T>
 struct BitWiseRightShiftable : crtp<T, BitWiseRightShiftable>
 {
-    constexpr T operator>>(T const& other) const
+    FLUENT_NODISCARD constexpr T operator>>(T const& other) const
     {
         return T(this->underlying().get() >> other.get());
     }
@@ -265,36 +256,36 @@ struct BitWiseRightShiftable : crtp<T, BitWiseRightShiftable>
 template <typename T>
 struct Comparable : crtp<T, Comparable>
 {
-    constexpr bool operator<(T const& other) const
+    FLUENT_NODISCARD constexpr bool operator<(T const& other) const
     {
         return this->underlying().get() < other.get();
     }
-    constexpr bool operator>(T const& other) const
+    FLUENT_NODISCARD constexpr bool operator>(T const& other) const
     {
         return other.get() < this->underlying().get();
     }
-    constexpr bool operator<=(T const& other) const
+    FLUENT_NODISCARD constexpr bool operator<=(T const& other) const
     {
         return !(other.get() < this->underlying().get());
     }
-    constexpr bool operator>=(T const& other) const
+    FLUENT_NODISCARD constexpr bool operator>=(T const& other) const
     {
         return !(*this < other);
     }
 // On Visual Studio before 19.22, you cannot define constexpr with friend function
 // See: https://stackoverflow.com/a/60400110
 #if defined(_MSC_VER) && _MSC_VER < 1922
-    constexpr bool operator==(T const& other) const
+    FLUENT_NODISCARD constexpr bool operator==(T const& other) const
     {
         return !(*this < other) && !(other.get() < this->underlying().get());
     }
 #else
-    friend constexpr bool operator==(Comparable<T> const& self, T const& other)
+    friend FLUENT_NODISCARD constexpr bool operator==(Comparable<T> const& self, T const& other)
     {
         return !(self < other) && !(other.get() < self.underlying().get());
     }
 #endif
-    constexpr bool operator!=(T const& other) const
+    FLUENT_NODISCARD constexpr bool operator!=(T const& other) const
     {
         return !(*this == other);
     }
@@ -306,11 +297,11 @@ struct Dereferencable;
 template< typename T, typename Parameter, template< typename > class ... Skills >
 struct Dereferencable<NamedType<T, Parameter, Skills...>> : crtp<NamedType<T, Parameter, Skills...>, Dereferencable>
 {
-    constexpr T& operator*() &
+    FLUENT_NODISCARD constexpr T& operator*() &
     {
         return this->underlying().get();
     }
-    constexpr std::remove_reference_t<T> const& operator*() const &
+    FLUENT_NODISCARD constexpr std::remove_reference_t<T> const& operator*() const &
     {
         return this->underlying().get();
     }
@@ -322,7 +313,7 @@ struct ImplicitlyConvertibleTo
     template <typename T>
     struct templ : crtp<T, templ>
     {
-        constexpr operator Destination() const
+        FLUENT_NODISCARD constexpr operator Destination() const
         {
             return this->underlying().get();
         }
@@ -360,11 +351,11 @@ struct FunctionCallable;
 template <typename T, typename Parameter, template <typename> class... Skills>
 struct FunctionCallable<NamedType<T, Parameter, Skills...>> : crtp<NamedType<T, Parameter, Skills...>, FunctionCallable>
 {
-    constexpr operator T const&() const
+    FLUENT_NODISCARD constexpr operator T const&() const
     {
         return this->underlying().get();
     }
-    constexpr operator T&()
+    FLUENT_NODISCARD constexpr operator T&()
     {
         return this->underlying().get();
     }
@@ -376,11 +367,11 @@ struct MethodCallable;
 template <typename T, typename Parameter, template <typename> class... Skills>
 struct MethodCallable<NamedType<T, Parameter, Skills...>> : crtp<NamedType<T, Parameter, Skills...>, MethodCallable>
 {
-    FLUENT_CONSTEXPR17 std::remove_reference_t<T> const* operator->() const
+    FLUENT_NODISCARD FLUENT_CONSTEXPR17 std::remove_reference_t<T> const* operator->() const
     {
         return std::addressof(this->underlying().get());
     }
-    FLUENT_CONSTEXPR17 std::remove_reference_t<T>* operator->()
+    FLUENT_NODISCARD FLUENT_CONSTEXPR17 std::remove_reference_t<T>* operator->()
     {
         return std::addressof(this->underlying().get());
     }

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -32,7 +32,7 @@ struct PostIncrementable : crtp<T, PostIncrementable>
 
     T operator++(int)
     {
-        return this->underlying().get()++;
+        return T(this->underlying().get()++);
     }
 
     IGNORE_SHOULD_RETURN_REFERENCE_TO_THIS_END
@@ -59,7 +59,7 @@ struct PostDecrementable : crtp<T, PostDecrementable>
 
     T operator--(int)
     {
-        return this->underlying().get()--;
+        return T( this->underlying().get()-- );
     }
 
     IGNORE_SHOULD_RETURN_REFERENCE_TO_THIS_END

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -8,6 +8,22 @@
 #include <iostream>
 #include <memory>
 
+// C++17 detection
+#if defined(_MSC_VER) && (defined(_HAS_CXX17) && _HAS_CXX17)
+#    define FLUENT_CPP17_PRESENT 1
+#elif __cplusplus >= 201703L
+#    define FLUENT_CPP17_PRESENT 1
+#else
+#    define FLUENT_CPP17_PRESENT 0
+#endif
+
+// C++17 constexpr additions
+#if FLUENT_CPP17_PRESENT
+#    define FLUENT_CONSTEXPR17 constexpr
+#else
+#    define FLUENT_CONSTEXPR17 
+#endif
+
 namespace fluent
 {
 
@@ -16,7 +32,7 @@ struct PreIncrementable : crtp<T, PreIncrementable>
 {
     IGNORE_SHOULD_RETURN_REFERENCE_TO_THIS_BEGIN
 
-    T& operator++()
+    FLUENT_CONSTEXPR17 T& operator++()
     {
         ++this->underlying().get();
         return this->underlying();
@@ -30,7 +46,7 @@ struct PostIncrementable : crtp<T, PostIncrementable>
 {
     IGNORE_SHOULD_RETURN_REFERENCE_TO_THIS_BEGIN
 
-    T operator++(int)
+    FLUENT_CONSTEXPR17 T operator++(int)
     {
         return T(this->underlying().get()++);
     }
@@ -43,7 +59,7 @@ struct PreDecrementable : crtp<T, PreDecrementable>
 {
     IGNORE_SHOULD_RETURN_REFERENCE_TO_THIS_BEGIN
 
-    T& operator--()
+    FLUENT_CONSTEXPR17 T& operator--()
     {
         --this->underlying().get();
         return this->underlying();
@@ -57,7 +73,7 @@ struct PostDecrementable : crtp<T, PostDecrementable>
 {
     IGNORE_SHOULD_RETURN_REFERENCE_TO_THIS_BEGIN
 
-    T operator--(int)
+    FLUENT_CONSTEXPR17 T operator--(int)
     {
         return T( this->underlying().get()-- );
     }

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -263,6 +263,23 @@ struct Comparable : crtp<T, Comparable>
     }
 };
 
+template< typename T >
+struct Dereferencable;
+
+template< typename T, typename Parameter, template< typename > class ... Skills >
+struct Dereferencable<NamedType<T, Parameter, Skills...>> : crtp<NamedType<T, Parameter, Skills...>, Dereferencable>
+{
+    T& operator*() &
+    {
+        return this->underlying().get();
+    }
+
+    std::remove_reference_t<T> const& operator*() const &
+    {
+        return this->underlying().get();
+    }
+};
+
 template <typename Destination>
 struct ImplicitlyConvertibleTo
 {

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -249,27 +249,36 @@ struct BitWiseRightShiftable : crtp<T, BitWiseRightShiftable>
 template <typename T>
 struct Comparable : crtp<T, Comparable>
 {
-    bool operator<(T const& other) const
+    constexpr bool operator<(T const& other) const
     {
         return this->underlying().get() < other.get();
     }
-    bool operator>(T const& other) const
+    constexpr bool operator>(T const& other) const
     {
         return other.get() < this->underlying().get();
     }
-    bool operator<=(T const& other) const
+    constexpr bool operator<=(T const& other) const
     {
         return !(other.get() < this->underlying().get());
     }
-    bool operator>=(T const& other) const
+    constexpr bool operator>=(T const& other) const
     {
         return !(*this < other);
     }
-    friend bool operator==(Comparable<T> const& self, T const& other)
+// On Visual Studio before 19.22, you cannot define constexpr with friend function
+// See: https://stackoverflow.com/a/60400110
+#if defined(_MSC_VER) && _MSC_VER < 1922
+    constexpr bool operator==(T const& other) const
+    {
+        return !(*this < other) && !(other.get() < this->underlying().get());
+    }
+#else
+    friend constexpr bool operator==(Comparable<T> const& self, T const& other)
     {
         return !(self < other) && !(other.get() < self.underlying().get());
     }
-    bool operator!=(T const& other) const
+#endif
+    constexpr bool operator!=(T const& other) const
     {
         return !(*this == other);
     }

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -68,7 +68,10 @@ struct PostDecrementable : crtp<T, PostDecrementable>
 template <typename T>
 struct BinaryAddable : crtp<T, BinaryAddable>
 {
-   T operator+(T const& other) const { return T(this->underlying().get() + other.get()); }
+    constexpr T operator+(T const& other) const
+    {
+        return T(this->underlying().get() + other.get());
+    }
     T& operator+=(T const& other)
     {
         this->underlying().get() += other.get();
@@ -79,7 +82,10 @@ struct BinaryAddable : crtp<T, BinaryAddable>
 template <typename T>
 struct UnaryAddable : crtp<T, UnaryAddable>
 {
-   T operator+() const { return T(+this->underlying().get()); }
+    constexpr T operator+() const
+    {
+        return T(+this->underlying().get());
+    }
 };
 
 template <typename T>
@@ -92,7 +98,10 @@ struct Addable : BinaryAddable<T>, UnaryAddable<T>
 template <typename T>
 struct BinarySubtractable : crtp<T, BinarySubtractable>
 {
-   T operator-(T const& other) const { return T(this->underlying().get() - other.get()); }
+    constexpr T operator-(T const& other) const
+    {
+        return T(this->underlying().get() - other.get());
+    }
     T& operator-=(T const& other)
     {
         this->underlying().get() -= other.get();
@@ -103,7 +112,10 @@ struct BinarySubtractable : crtp<T, BinarySubtractable>
 template <typename T>
 struct UnarySubtractable : crtp<T, UnarySubtractable>
 {
-   T operator-() const { return T(-this->underlying().get()); }
+    constexpr T operator-() const
+    {
+        return T(-this->underlying().get());
+    }
 };
    
 template <typename T>
@@ -116,7 +128,7 @@ struct Subtractable : BinarySubtractable<T>, UnarySubtractable<T>
 template <typename T>
 struct Multiplicable : crtp<T, Multiplicable>
 {
-    T operator*(T const& other) const
+    constexpr T operator*(T const& other) const
     {
         return T(this->underlying().get() * other.get());
     }
@@ -130,7 +142,7 @@ struct Multiplicable : crtp<T, Multiplicable>
 template <typename T>
 struct Divisible : crtp<T, Divisible>
 {
-    T operator/(T const& other) const
+    constexpr T operator/(T const& other) const
     {
         return T(this->underlying().get() / other.get());
     }
@@ -144,7 +156,7 @@ struct Divisible : crtp<T, Divisible>
 template <typename T>
 struct Modulable : crtp<T, Modulable>
 {
-    T operator%(T const& other) const
+    constexpr T operator%(T const& other) const
     {
         return T(this->underlying().get() % other.get());
     }
@@ -158,7 +170,7 @@ struct Modulable : crtp<T, Modulable>
 template <typename T>
 struct BitWiseInvertable : crtp<T, BitWiseInvertable>
 {
-    T operator~() const
+    constexpr T operator~() const
     {
         return T(~this->underlying().get());
     }
@@ -167,7 +179,7 @@ struct BitWiseInvertable : crtp<T, BitWiseInvertable>
 template <typename T>
 struct BitWiseAndable : crtp<T, BitWiseAndable>
 {
-    T operator&(T const& other) const
+    constexpr T operator&(T const& other) const
     {
         return T(this->underlying().get() & other.get());
     }
@@ -181,7 +193,7 @@ struct BitWiseAndable : crtp<T, BitWiseAndable>
 template <typename T>
 struct BitWiseOrable : crtp<T, BitWiseOrable>
 {
-    T operator|(T const& other) const
+    constexpr T operator|(T const& other) const
     {
         return T(this->underlying().get() | other.get());
     }
@@ -195,7 +207,7 @@ struct BitWiseOrable : crtp<T, BitWiseOrable>
 template <typename T>
 struct BitWiseXorable : crtp<T, BitWiseXorable>
 {
-    T operator^(T const& other) const
+    constexpr T operator^(T const& other) const
     {
         return T(this->underlying().get() ^ other.get());
     }
@@ -209,7 +221,7 @@ struct BitWiseXorable : crtp<T, BitWiseXorable>
 template <typename T>
 struct BitWiseLeftShiftable : crtp<T, BitWiseLeftShiftable>
 {
-    T operator<<(T const& other) const
+    constexpr T operator<<(T const& other) const
     {
         return T(this->underlying().get() << other.get());
     }
@@ -223,7 +235,7 @@ struct BitWiseLeftShiftable : crtp<T, BitWiseLeftShiftable>
 template <typename T>
 struct BitWiseRightShiftable : crtp<T, BitWiseRightShiftable>
 {
-    T operator>>(T const& other) const
+    constexpr T operator>>(T const& other) const
     {
         return T(this->underlying().get() >> other.get());
     }
@@ -269,12 +281,11 @@ struct Dereferencable;
 template< typename T, typename Parameter, template< typename > class ... Skills >
 struct Dereferencable<NamedType<T, Parameter, Skills...>> : crtp<NamedType<T, Parameter, Skills...>, Dereferencable>
 {
-    T& operator*() &
+    constexpr T& operator*() &
     {
         return this->underlying().get();
     }
-
-    std::remove_reference_t<T> const& operator*() const &
+    constexpr std::remove_reference_t<T> const& operator*() const &
     {
         return this->underlying().get();
     }

--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -376,11 +376,11 @@ struct MethodCallable;
 template <typename T, typename Parameter, template <typename> class... Skills>
 struct MethodCallable<NamedType<T, Parameter, Skills...>> : crtp<NamedType<T, Parameter, Skills...>, MethodCallable>
 {
-    std::remove_reference_t<T> const* operator->() const
+    constexpr std::remove_reference_t<T> const* operator->() const
     {
         return std::addressof(this->underlying().get());
     }
-    std::remove_reference_t<T>* operator->()
+    constexpr std::remove_reference_t<T>* operator->()
     {
         return std::addressof(this->underlying().get());
     }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -616,3 +616,51 @@ TEST_CASE("Dereferencable")
         CHECK( value == 28 );
     }
 }
+
+TEST_CASE("PreIncrementable")
+{
+    using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PreIncrementable>;
+
+    {
+        StrongInt a{1};
+        StrongInt b = ++a;
+        CHECK( a.get() == 2 );
+        CHECK( b.get() == 2 );
+    }
+}
+
+TEST_CASE("PostIncrementable")
+{
+    using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PostIncrementable>;
+
+    {
+        StrongInt a{1};
+        StrongInt b = a++;
+        CHECK( a.get() == 2 );
+        CHECK( b.get() == 1 );
+    }
+}
+
+TEST_CASE("PreDecrementable")
+{
+    using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PreDecrementable>;
+
+    {
+        StrongInt a{1};
+        StrongInt b = --a;
+        CHECK( a.get() == 0 );
+        CHECK( b.get() == 0 );
+    }
+}
+
+TEST_CASE("PostDecrementable")
+{
+    using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PostDecrementable>;
+
+    {
+        StrongInt a{1};
+        StrongInt b = a--;
+        CHECK( a.get() == 0 );
+        CHECK( b.get() == 1 );
+    }
+}

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -338,7 +338,7 @@ TEST_CASE("BitWiseXorable constexpr")
     using BitWiseXorableType = fluent::NamedType<int, struct BitWiseXorableTag, fluent::BitWiseXorable>;
     constexpr BitWiseXorableType s1(2);
     constexpr BitWiseXorableType s2(64);
-    static_assert((s1 ^ s2).get() == (2 ^ 64), "BitWiseXorable is not constexpr");
+    static_assert((s1 ^ s2).get() == 66, "BitWiseXorable is not constexpr");
 }
 
 TEST_CASE("BitWiseLeftShiftable")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -705,7 +705,7 @@ constexpr bool operator==(testFunctionCallable_B const& a1, testFunctionCallable
     return a1.x == a2.x;
 }
 
-constexpr const int functionTakingB(testFunctionCallable_B const& b)
+constexpr int functionTakingB(testFunctionCallable_B const& b)
 {
     return b.x;
 };

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -989,7 +989,8 @@ TEST_CASE("Dereferencable constexpr")
     using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::Dereferencable>;
 
     constexpr StrongInt a{28};
-    static_assert( *a, "Dereferencable is not constexpr");
+    static_assert( *a == 28, "Dereferencable is not constexpr");
+    static_assert( *StrongInt{28} == 28, "Dereferencable is not constexpr");
 }
 
 TEST_CASE("PreIncrementable")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -159,9 +159,8 @@ TEST_CASE("BinaryAddable constexpr")
 TEST_CASE("BinaryAddable constexpr C++17")
 {
     using BinaryAddableType = fluent::NamedType<int, struct BinaryAddableTag, fluent::BinaryAddable>;
-    constexpr BinaryAddableType s1(12);
-    constexpr BinaryAddableType s2(10);
-    static_assert(BinaryAddableType{12}.operator+=( s2 ).get() == 22, "BinaryAddable is not constexpr");
+    constexpr BinaryAddableType s(10);
+    static_assert(BinaryAddableType{12}.operator+=( s ).get() == 22, "BinaryAddable is not constexpr");
 }
 #endif
 
@@ -217,8 +216,8 @@ TEST_CASE("BinarySubtractable constexpr")
 TEST_CASE("BinarySubtractable constexpr C++17")
 {
     using BinarySubtractableType = fluent::NamedType<int, struct BinarySubtractableTag, fluent::BinarySubtractable>;
-    constexpr BinarySubtractableType s2(10);
-    static_assert(BinarySubtractableType{12}.operator-=( s2 ).get() == 2, "BinarySubtractable is not constexpr");
+    constexpr BinarySubtractableType s(10);
+    static_assert(BinarySubtractableType{12}.operator-=( s ).get() == 2, "BinarySubtractable is not constexpr");
 }
 #endif
 
@@ -259,8 +258,8 @@ TEST_CASE("Multiplicable constexpr")
 TEST_CASE("Multiplicable constexpr C++17")
 {
     using MultiplicableType = fluent::NamedType<int, struct MultiplicableTag, fluent::Multiplicable>;
-    constexpr MultiplicableType s2(10);
-    static_assert(MultiplicableType{12}.operator*=( s2 ).get() == 120, "Multiplicable is not constexpr");
+    constexpr MultiplicableType s(10);
+    static_assert(MultiplicableType{12}.operator*=( s ).get() == 120, "Multiplicable is not constexpr");
 }
 #endif
 
@@ -286,8 +285,8 @@ TEST_CASE("Divisible constexpr")
 TEST_CASE("Divisible constexpr C++17")
 {
     using DivisibleType = fluent::NamedType<int, struct DivisibleTag, fluent::Divisible>;
-    constexpr DivisibleType s2(10);
-    static_assert(DivisibleType{120}.operator/=( s2 ).get() == 12, "Divisible is not constexpr");
+    constexpr DivisibleType s(10);
+    static_assert(DivisibleType{120}.operator/=( s ).get() == 12, "Divisible is not constexpr");
 }
 #endif
 
@@ -313,8 +312,8 @@ TEST_CASE("Modulable constexpr")
 TEST_CASE("Modulable constexpr C++17")
 {
     using ModulableType = fluent::NamedType<int, struct ModulableTag, fluent::Modulable>;
-    constexpr ModulableType s2(2);
-    static_assert(ModulableType{5}.operator%=( s2 ).get() == 1, "Modulable is not constexpr");
+    constexpr ModulableType s(2);
+    static_assert(ModulableType{5}.operator%=( s ).get() == 1, "Modulable is not constexpr");
 }
 #endif
 
@@ -354,8 +353,8 @@ TEST_CASE("BitWiseAndable constexpr")
 TEST_CASE("BitWiseAndable constexpr C++17")
 {
     using BitWiseAndableType = fluent::NamedType<int, struct BitWiseAndableTag, fluent::BitWiseAndable>;
-    constexpr BitWiseAndableType s2(64);
-    static_assert(BitWiseAndableType{2}.operator&=( s2 ).get() == (2 & 64), "BitWiseAndable is not constexpr");
+    constexpr BitWiseAndableType s(64);
+    static_assert(BitWiseAndableType{2}.operator&=( s ).get() == (2 & 64), "BitWiseAndable is not constexpr");
 }
 #endif
 
@@ -381,8 +380,8 @@ TEST_CASE("BitWiseOrable constexpr")
 TEST_CASE("BitWiseOrable constexpr C++17")
 {
     using BitWiseOrableType = fluent::NamedType<int, struct BitWiseOrableTag, fluent::BitWiseOrable>;
-    constexpr BitWiseOrableType s2(64);
-    static_assert(BitWiseOrableType{2}.operator|=( s2 ).get() == (2 | 64), "BitWiseOrable is not constexpr");
+    constexpr BitWiseOrableType s(64);
+    static_assert(BitWiseOrableType{2}.operator|=( s ).get() == (2 | 64), "BitWiseOrable is not constexpr");
 }
 #endif
 
@@ -408,8 +407,8 @@ TEST_CASE("BitWiseXorable constexpr")
 TEST_CASE("BitWiseXorable constexpr C++17")
 {
     using BitWiseXorableType = fluent::NamedType<int, struct BitWiseXorableTag, fluent::BitWiseXorable>;
-    constexpr BitWiseXorableType s2(64);
-    static_assert(BitWiseXorableType{2}.operator^=( s2 ).get() == 66, "BitWiseXorable is not constexpr");
+    constexpr BitWiseXorableType s(64);
+    static_assert(BitWiseXorableType{2}.operator^=( s ).get() == 66, "BitWiseXorable is not constexpr");
 }
 #endif
 
@@ -438,8 +437,8 @@ TEST_CASE("BitWiseLeftShiftable constexpr C++17")
 {
     using BitWiseLeftShiftableType =
         fluent::NamedType<int, struct BitWiseLeftShiftableTag, fluent::BitWiseLeftShiftable>;
-    constexpr BitWiseLeftShiftableType s2(3);
-    static_assert(BitWiseLeftShiftableType{2}.operator<<=( s2 ).get() == (2 << 3 ), "BitWiseLeftShiftable is not constexpr");
+    constexpr BitWiseLeftShiftableType s(3);
+    static_assert(BitWiseLeftShiftableType{2}.operator<<=( s ).get() == (2 << 3), "BitWiseLeftShiftable is not constexpr");
 }
 #endif
 
@@ -468,8 +467,8 @@ TEST_CASE("BitWiseRightShiftable constexpr C++17")
 {
     using BitWiseRightShiftableType =
         fluent::NamedType<int, struct BitWiseRightShiftableTag, fluent::BitWiseRightShiftable>;
-    constexpr BitWiseRightShiftableType s2(3);
-    static_assert(BitWiseRightShiftableType{2}.operator>>=( s2 ).get() == (2 >> 3 ), "BitWiseRightShiftable is not constexpr");
+    constexpr BitWiseRightShiftableType s(3);
+    static_assert(BitWiseRightShiftableType{2}.operator>>=( s ).get() == (2 >> 3), "BitWiseRightShiftable is not constexpr");
 }
 #endif
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -575,3 +575,12 @@ TEST_CASE("Version macros are defined")
     ss << NAMED_TYPE_VERSION_MAJOR << '.' << NAMED_TYPE_VERSION_MINOR << '.' << NAMED_TYPE_VERSION_PATCH;
     CHECK(ss.str() == NAMED_TYPE_VERSION);
 }
+
+TEST_CASE("Printable")
+{
+    using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::Printable>;
+
+    std::ostringstream oss;
+    oss << StrongInt( 42 );
+    CHECK(oss.str() == "42");
+}

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -153,6 +153,7 @@ TEST_CASE("BinaryAddable constexpr")
     constexpr BinaryAddableType s1(12);
     constexpr BinaryAddableType s2(10);
     static_assert((s1 + s2).get() == 22, "BinaryAddable is not constexpr");
+    static_assert(BinaryAddableType{12}.operator+=( s2 ).get() == 22, "BinaryAddable is not constexpr");
 }
 
 TEST_CASE("UnaryAddable")
@@ -201,6 +202,7 @@ TEST_CASE("BinarySubtractable constexpr")
     constexpr BinarySubtractableType s1(12);
     constexpr BinarySubtractableType s2(10);
     static_assert((s1 - s2).get() == 2, "BinarySubtractable is not constexpr");
+    static_assert(BinarySubtractableType{12}.operator-=( s2 ).get() == 2, "BinarySubtractable is not constexpr");
 }
 
 TEST_CASE("UnarySubtractable")
@@ -234,6 +236,7 @@ TEST_CASE("Multiplicable constexpr")
     constexpr MultiplicableType s1(12);
     constexpr MultiplicableType s2(10);
     static_assert((s1 * s2).get() == 120, "Multiplicable is not constexpr");
+    static_assert(MultiplicableType{12}.operator*=( s2 ).get() == 120, "Multiplicable is not constexpr");
 }
 
 TEST_CASE("Divisible")
@@ -252,6 +255,7 @@ TEST_CASE("Divisible constexpr")
     constexpr DivisibleType s1(120);
     constexpr DivisibleType s2(10);
     static_assert((s1 / s2).get() == 12, "Divisible is not constexpr");
+    static_assert(DivisibleType{120}.operator/=( s2 ).get() == 12, "Divisible is not constexpr");
 }
 
 
@@ -271,6 +275,7 @@ TEST_CASE("Modulable constexpr")
     constexpr ModulableType s1(5);
     constexpr ModulableType s2(2);
     static_assert((s1 % s2).get() == 1, "Modulable is not constexpr");
+    static_assert(ModulableType{5}.operator%=( s2 ).get() == 1, "Modulable is not constexpr");
 }
 
 TEST_CASE("BitWiseInvertable")
@@ -303,6 +308,7 @@ TEST_CASE("BitWiseAndable constexpr")
     constexpr BitWiseAndableType s1(2);
     constexpr BitWiseAndableType s2(64);
     static_assert((s1 & s2).get() == (2 & 64), "BitWiseAndable is not constexpr");
+    static_assert(BitWiseAndableType{2}.operator&=( s2 ).get() == (2 & 64), "BitWiseAndable is not constexpr");
 }
 
 TEST_CASE("BitWiseOrable")
@@ -321,6 +327,7 @@ TEST_CASE("BitWiseOrable constexpr")
     constexpr BitWiseOrableType s1(2);
     constexpr BitWiseOrableType s2(64);
     static_assert((s1 | s2).get() == (2 | 64), "BitWiseOrable is not constexpr");
+    static_assert(BitWiseOrableType{2}.operator|=( s2 ).get() == (2 | 64), "BitWiseOrable is not constexpr");
 }
 
 TEST_CASE("BitWiseXorable")
@@ -339,6 +346,7 @@ TEST_CASE("BitWiseXorable constexpr")
     constexpr BitWiseXorableType s1(2);
     constexpr BitWiseXorableType s2(64);
     static_assert((s1 ^ s2).get() == 66, "BitWiseXorable is not constexpr");
+    static_assert(BitWiseXorableType{2}.operator^=( s2 ).get() == 66, "BitWiseXorable is not constexpr");
 }
 
 TEST_CASE("BitWiseLeftShiftable")
@@ -359,6 +367,7 @@ TEST_CASE("BitWiseLeftShiftable constexpr")
     constexpr BitWiseLeftShiftableType s1(2);
     constexpr BitWiseLeftShiftableType s2(3);
     static_assert((s1 << s2).get() == (2 << 3), "BitWiseLeftShiftable is not constexpr");
+    static_assert(BitWiseLeftShiftableType{2}.operator<<=( s2 ).get() == (2 << 3 ), "BitWiseLeftShiftable is not constexpr");
 }
 
 TEST_CASE("BitWiseRightShiftable")
@@ -379,6 +388,7 @@ TEST_CASE("BitWiseRightShiftable constexpr")
     constexpr BitWiseRightShiftableType s1(2);
     constexpr BitWiseRightShiftableType s2(3);
     static_assert((s1 >> s2).get() == (2 >> 3), "BitWiseRightShiftable is not constexpr");
+    static_assert(BitWiseRightShiftableType{2}.operator>>=( s2 ).get() == (2 >> 3 ), "BitWiseRightShiftable is not constexpr");
 }
 
 TEST_CASE("Comparable")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -835,6 +835,14 @@ TEST_CASE("PreIncrementable")
     CHECK( b.get() == 2 );
 }
 
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("PreIncrementable constexpr")
+{
+    using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PreIncrementable>;
+    static_assert( (++StrongInt{1}).get() == 2, "PreIncrementable is not constexpr");
+}
+#endif
+
 TEST_CASE("PostIncrementable")
 {
     using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PostIncrementable>;
@@ -843,6 +851,14 @@ TEST_CASE("PostIncrementable")
     CHECK( a.get() == 2 );
     CHECK( b.get() == 1 );
 }
+
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("PostIncrementable constexpr")
+{
+    using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PostIncrementable>;
+    static_assert( (StrongInt{1}++).get() == 1, "PostIncrementable is not constexpr");
+}
+#endif
 
 TEST_CASE("PreDecrementable")
 {
@@ -853,6 +869,14 @@ TEST_CASE("PreDecrementable")
     CHECK( b.get() == 0 );
 }
 
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("PreDecrementable constexpr")
+{
+    using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PreDecrementable>;
+    static_assert( (--StrongInt{1}).get() == 0, "PreDecrementable is not constexpr");
+}
+#endif
+
 TEST_CASE("PostDecrementable")
 {
     using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PostDecrementable>;
@@ -861,3 +885,11 @@ TEST_CASE("PostDecrementable")
     CHECK( a.get() == 0 );
     CHECK( b.get() == 1 );
 }
+
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("PostDecrementable constexpr")
+{
+    using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PostDecrementable>;
+    static_assert( (StrongInt{1}--).get() == 1, "PostDecrementable is not constexpr");
+}
+#endif

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -710,6 +710,36 @@ TEST_CASE("Method callable")
     REQUIRE(constStrongA->constMethod() == 42);
 }
 
+TEST_CASE("Method callable constexpr")
+{
+    class A
+    {
+    public:
+        constexpr A(int x_) : x(x_)
+        {
+        }
+        A(A const&) = delete; // ensures that invoking a method doesn't make a copy
+        A(A&&) = default;
+
+        constexpr int method()
+        {
+            return x;
+        }
+        constexpr int constMethod() const
+        {
+            return x;
+        }
+
+    private:
+        int x;
+    };
+
+    using StrongA = fluent::NamedType<A, struct StrongATag, fluent::MethodCallable>;
+    constexpr const StrongA constStrongA(A((42)));
+    static_assert( StrongA(A(42))->method() == 42, "MethodCallable is not constexpr");
+    static_assert(constStrongA->constMethod() == 42, "MethodCallable is not constexpr");
+}
+
 TEST_CASE("Callable")
 {
     class A

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -705,17 +705,21 @@ constexpr bool operator==(testFunctionCallable_B const& a1, testFunctionCallable
     return a1.x == a2.x;
 }
 
+constexpr const int functionTakingB(testFunctionCallable_B const& b)
+{
+    return b.x;
+};
+
 TEST_CASE("Function callable constexpr")
 {
     using B = testFunctionCallable_B;
-    const auto functionTakingB = [](B const& b) constexpr { return b.x; };
 
     using StrongB = fluent::NamedType<B, struct StrongATag, fluent::FunctionCallable>;
     constexpr StrongB constStrongB(B(42));
-    static_assert(functionTakingB(StrongB(B(42))) == 42);
-    static_assert(functionTakingB(constStrongB) == 42);
-    static_assert(StrongB(B(42)) + StrongB(B(42)) == 84);
-    static_assert(constStrongB + constStrongB == 84);
+    static_assert(functionTakingB(StrongB(B(42))) == 42, "FunctionCallable is not constexpr");
+    static_assert(functionTakingB(constStrongB) == 42, "FunctionCallable is not constexpr");
+    static_assert(StrongB(B(42)) + StrongB(B(42)) == 84, "FunctionCallable is not constexpr");
+    static_assert(constStrongB + constStrongB == 84, "FunctionCallable is not constexpr");
 }
 
 TEST_CASE("Method callable")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -445,6 +445,34 @@ TEST_CASE("ConvertibleWithOperator")
     REQUIRE(b.x == 42);
 }
 
+TEST_CASE("ConvertibleWithOperator constexpr")
+{
+    struct B
+    {
+        constexpr B(int x_) : x(x_)
+        {
+        }
+        int x;
+    };
+
+    struct A
+    {
+        constexpr A(int x_) : x(x_)
+        {
+        }
+        constexpr operator B() const
+        {
+            return B(x);
+        }
+        int x;
+    };
+
+    using StrongA = fluent::NamedType<A, struct StrongATag, fluent::ImplicitlyConvertibleTo<B>::templ>;
+    constexpr StrongA strongA(A(42));
+    constexpr B b = strongA;
+    static_assert(b.x == 42, "ImplicitlyConvertibleTo is not constexpr");
+}
+
 TEST_CASE("ConvertibleWithConstructor")
 {
     struct A
@@ -469,12 +497,44 @@ TEST_CASE("ConvertibleWithConstructor")
     REQUIRE(b.x == 42);
 }
 
+TEST_CASE("ConvertibleWithConstructor constexpr")
+{
+    struct A
+    {
+        constexpr A(int x_) : x(x_)
+        {
+        }
+        int x;
+    };
+
+    struct B
+    {
+        constexpr B(A a) : x(a.x)
+        {
+        }
+        int x;
+    };
+
+    using StrongA = fluent::NamedType<A, struct StrongATag, fluent::ImplicitlyConvertibleTo<B>::templ>;
+    constexpr StrongA strongA(A(42));
+    constexpr B b = strongA;
+    static_assert(b.x == 42, "ImplicitlyConvertibleTo is not constexpr");
+}
+
 TEST_CASE("ConvertibleToItself")
 {
     using MyInt = fluent::NamedType<int, struct MyIntTag, fluent::ImplicitlyConvertibleTo<int>::templ>;
     MyInt myInt(42);
     int i = myInt;
     REQUIRE(i == 42);
+}
+
+TEST_CASE("ConvertibleToItself constexpr")
+{
+    using MyInt = fluent::NamedType<int, struct MyIntTag, fluent::ImplicitlyConvertibleTo<int>::templ>;
+    constexpr MyInt myInt(42);
+    constexpr int i = myInt;
+    static_assert(i == 42, "ImplicitlyConvertibleTo is not constexpr");
 }
 
 TEST_CASE("Hash")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -26,7 +26,7 @@ decltype(auto) tee(T&& value)
 }
 
 using Meter = fluent::NamedType<unsigned long long, struct MeterParameter, fluent::Addable, fluent::Comparable>;
-Meter operator"" _meter(unsigned long long value)
+constexpr Meter operator"" _meter(unsigned long long value)
 {
     return Meter(value);
 }
@@ -397,6 +397,24 @@ TEST_CASE("Comparable")
     REQUIRE((11_meter >= 10_meter));
     REQUIRE((10_meter >= 10_meter));
     REQUIRE(!(9_meter >= 10_meter));
+}
+
+TEST_CASE("Comparable constexpr")
+{
+    static_assert((10_meter == 10_meter), "Comparable is not constexpr");
+    static_assert(!(10_meter == 11_meter), "Comparable is not constexpr");
+    static_assert((10_meter != 11_meter), "Comparable is not constexpr");
+    static_assert(!(10_meter != 10_meter), "Comparable is not constexpr");
+    static_assert((10_meter < 11_meter), "Comparable is not constexpr");
+    static_assert(!(10_meter < 10_meter), "Comparable is not constexpr");
+    static_assert((10_meter <= 10_meter), "Comparable is not constexpr");
+    static_assert((10_meter <= 11_meter), "Comparable is not constexpr");
+    static_assert(!(10_meter <= 9_meter), "Comparable is not constexpr");
+    static_assert((11_meter > 10_meter), "Comparable is not constexpr");
+    static_assert(!(10_meter > 11_meter), "Comparable is not constexpr");
+    static_assert((11_meter >= 10_meter), "Comparable is not constexpr");
+    static_assert((10_meter >= 10_meter), "Comparable is not constexpr");
+    static_assert(!(9_meter >= 10_meter), "Comparable is not constexpr");
 }
 
 TEST_CASE("ConvertibleWithOperator")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -620,47 +620,35 @@ TEST_CASE("Dereferencable")
 TEST_CASE("PreIncrementable")
 {
     using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PreIncrementable>;
-
-    {
-        StrongInt a{1};
-        StrongInt b = ++a;
-        CHECK( a.get() == 2 );
-        CHECK( b.get() == 2 );
-    }
+    StrongInt a{1};
+    StrongInt b = ++a;
+    CHECK( a.get() == 2 );
+    CHECK( b.get() == 2 );
 }
 
 TEST_CASE("PostIncrementable")
 {
     using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PostIncrementable>;
-
-    {
-        StrongInt a{1};
-        StrongInt b = a++;
-        CHECK( a.get() == 2 );
-        CHECK( b.get() == 1 );
-    }
+    StrongInt a{1};
+    StrongInt b = a++;
+    CHECK( a.get() == 2 );
+    CHECK( b.get() == 1 );
 }
 
 TEST_CASE("PreDecrementable")
 {
     using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PreDecrementable>;
-
-    {
-        StrongInt a{1};
-        StrongInt b = --a;
-        CHECK( a.get() == 0 );
-        CHECK( b.get() == 0 );
-    }
+    StrongInt a{1};
+    StrongInt b = --a;
+    CHECK( a.get() == 0 );
+    CHECK( b.get() == 0 );
 }
 
 TEST_CASE("PostDecrementable")
 {
     using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PostDecrementable>;
-
-    {
-        StrongInt a{1};
-        StrongInt b = a--;
-        CHECK( a.get() == 0 );
-        CHECK( b.get() == 1 );
-    }
+    StrongInt a{1};
+    StrongInt b = a--;
+    CHECK( a.get() == 0 );
+    CHECK( b.get() == 1 );
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -584,3 +584,35 @@ TEST_CASE("Printable")
     oss << StrongInt( 42 );
     CHECK(oss.str() == "42");
 }
+
+TEST_CASE("Dereferencable")
+{
+    using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::Dereferencable>;
+
+    {
+        StrongInt a{1};
+        int& value = *a;
+        CHECK( value == 1 );
+    }
+
+    {
+        const StrongInt a{1};
+        const int& value = *a;
+        CHECK( value == 1 );
+    }
+
+    {
+        StrongInt a{1};
+        int& value = *a;
+        value = 2;
+        CHECK( a.get() == 2 );
+    }
+
+    {
+        auto functionReturningStrongInt = []() { return StrongInt{28}; };
+        auto functionTakingInt = []( int value ) { return value; };
+
+        int value = functionTakingInt( *functionReturningStrongInt() );
+        CHECK( value == 28 );
+    }
+}

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -130,6 +130,15 @@ TEST_CASE("Addable")
     REQUIRE((+s1).get() == 12);
 }
 
+TEST_CASE("Addable constexpr")
+{
+    using AddableType = fluent::NamedType<int, struct AddableTag, fluent::Addable>;
+    constexpr AddableType s1(12);
+    constexpr AddableType s2(10);
+    static_assert((s1 + s2).get() == 22, "Addable is not constexpr");
+    static_assert((+s1).get() == 12, "Addable is not constexpr");
+}
+
 TEST_CASE("BinaryAddable")
 {
     using BinaryAddableType = fluent::NamedType<int, struct BinaryAddableTag, fluent::BinaryAddable>;
@@ -138,11 +147,26 @@ TEST_CASE("BinaryAddable")
     REQUIRE((s1 + s2).get() == 22);
 }
 
+TEST_CASE("BinaryAddable constexpr")
+{
+    using BinaryAddableType = fluent::NamedType<int, struct BinaryAddableTag, fluent::BinaryAddable>;
+    constexpr BinaryAddableType s1(12);
+    constexpr BinaryAddableType s2(10);
+    static_assert((s1 + s2).get() == 22, "BinaryAddable is not constexpr");
+}
+
 TEST_CASE("UnaryAddable")
 {
     using UnaryAddableType = fluent::NamedType<int, struct UnaryAddableTag, fluent::UnaryAddable>;
     UnaryAddableType s1(12);
     REQUIRE((+s1).get() == 12);
+}
+
+TEST_CASE("UnaryAddable constexpr")
+{
+    using UnaryAddableType = fluent::NamedType<int, struct UnaryAddableTag, fluent::UnaryAddable>;
+    constexpr UnaryAddableType s1(12);
+    static_assert((+s1).get() == 12, "UnaryAddable is not constexpr");
 }
 
 TEST_CASE("Subtractable")
@@ -154,12 +178,29 @@ TEST_CASE("Subtractable")
     REQUIRE((-s1).get() == -12);
 }
 
+TEST_CASE("Subtractable constexpr")
+{
+    using SubtractableType = fluent::NamedType<int, struct SubtractableTag, fluent::Subtractable>;
+    constexpr SubtractableType s1(12);
+    constexpr SubtractableType s2(10);
+    static_assert((s1 - s2).get() == 2, "Subtractable is not constexpr");
+    static_assert((-s1).get() == -12, "Subtractable is not constexpr");
+}
+
 TEST_CASE("BinarySubtractable")
 {
     using BinarySubtractableType = fluent::NamedType<int, struct BinarySubtractableTag, fluent::BinarySubtractable>;
     BinarySubtractableType s1(12);
     BinarySubtractableType s2(10);
     REQUIRE((s1 - s2).get() == 2);
+}
+
+TEST_CASE("BinarySubtractable constexpr")
+{
+    using BinarySubtractableType = fluent::NamedType<int, struct BinarySubtractableTag, fluent::BinarySubtractable>;
+    constexpr BinarySubtractableType s1(12);
+    constexpr BinarySubtractableType s2(10);
+    static_assert((s1 - s2).get() == 2, "BinarySubtractable is not constexpr");
 }
 
 TEST_CASE("UnarySubtractable")
@@ -169,6 +210,14 @@ TEST_CASE("UnarySubtractable")
     REQUIRE((-s).get() == -12);
 }
 
+TEST_CASE("UnarySubtractable constexpr")
+{
+    using UnarySubtractableType = fluent::NamedType<int, struct UnarySubtractableTag, fluent::UnarySubtractable>;
+    constexpr UnarySubtractableType s(12);
+    static_assert((-s).get() == -12, "UnarySubtractable is not constexpr");
+}
+
+
 TEST_CASE("Multiplicable")
 {
     using MultiplicableType = fluent::NamedType<int, struct MultiplicableTag, fluent::Multiplicable>;
@@ -177,6 +226,14 @@ TEST_CASE("Multiplicable")
     REQUIRE((s1 * s2).get() == 120);
     s1 *= s2;
     REQUIRE(s1.get() == 120);
+}
+
+TEST_CASE("Multiplicable constexpr")
+{
+    using MultiplicableType = fluent::NamedType<int, struct MultiplicableTag, fluent::Multiplicable>;
+    constexpr MultiplicableType s1(12);
+    constexpr MultiplicableType s2(10);
+    static_assert((s1 * s2).get() == 120, "Multiplicable is not constexpr");
 }
 
 TEST_CASE("Divisible")
@@ -189,6 +246,15 @@ TEST_CASE("Divisible")
     REQUIRE(s1.get() == 12);
 }
 
+TEST_CASE("Divisible constexpr")
+{
+    using DivisibleType = fluent::NamedType<int, struct DivisibleTag, fluent::Divisible>;
+    constexpr DivisibleType s1(120);
+    constexpr DivisibleType s2(10);
+    static_assert((s1 / s2).get() == 12, "Divisible is not constexpr");
+}
+
+
 TEST_CASE("Modulable")
 {
     using ModulableType = fluent::NamedType<int, struct ModulableTag, fluent::Modulable>;
@@ -199,11 +265,26 @@ TEST_CASE("Modulable")
     CHECK(s1.get() == 1);
 }
 
+TEST_CASE("Modulable constexpr")
+{
+    using ModulableType = fluent::NamedType<int, struct ModulableTag, fluent::Modulable>;
+    constexpr ModulableType s1(5);
+    constexpr ModulableType s2(2);
+    static_assert((s1 % s2).get() == 1, "Modulable is not constexpr");
+}
+
 TEST_CASE("BitWiseInvertable")
 {
     using BitWiseInvertableType = fluent::NamedType<int, struct BitWiseInvertableTag, fluent::BitWiseInvertable>;
     BitWiseInvertableType s1(13);
     CHECK((~s1).get() == (~13));
+}
+
+TEST_CASE("BitWiseInvertable constexpr")
+{
+    using BitWiseInvertableType = fluent::NamedType<int, struct BitWiseInvertableTag, fluent::BitWiseInvertable>;
+    constexpr BitWiseInvertableType s1(13);
+    static_assert((~s1).get() == (~13), "BitWiseInvertable is not constexpr");
 }
 
 TEST_CASE("BitWiseAndable")
@@ -216,6 +297,14 @@ TEST_CASE("BitWiseAndable")
     CHECK(s1.get() == (2 & 64));
 }
 
+TEST_CASE("BitWiseAndable constexpr")
+{
+    using BitWiseAndableType = fluent::NamedType<int, struct BitWiseAndableTag, fluent::BitWiseAndable>;
+    constexpr BitWiseAndableType s1(2);
+    constexpr BitWiseAndableType s2(64);
+    static_assert((s1 & s2).get() == (2 & 64), "BitWiseAndable is not constexpr");
+}
+
 TEST_CASE("BitWiseOrable")
 {
     using BitWiseOrableType = fluent::NamedType<int, struct BitWiseOrableTag, fluent::BitWiseOrable>;
@@ -226,6 +315,14 @@ TEST_CASE("BitWiseOrable")
     CHECK(s1.get() == (2 | 64));
 }
 
+TEST_CASE("BitWiseOrable constexpr")
+{
+    using BitWiseOrableType = fluent::NamedType<int, struct BitWiseOrableTag, fluent::BitWiseOrable>;
+    constexpr BitWiseOrableType s1(2);
+    constexpr BitWiseOrableType s2(64);
+    static_assert((s1 | s2).get() == (2 | 64), "BitWiseOrable is not constexpr");
+}
+
 TEST_CASE("BitWiseXorable")
 {
     using BitWiseXorableType = fluent::NamedType<int, struct BitWiseXorableTag, fluent::BitWiseXorable>;
@@ -234,6 +331,14 @@ TEST_CASE("BitWiseXorable")
     CHECK((s1 ^ s2).get() == (2 ^ 64));
     s1 ^= s2;
     CHECK(s1.get() == (2 ^ 64));
+}
+
+TEST_CASE("BitWiseXorable constexpr")
+{
+    using BitWiseXorableType = fluent::NamedType<int, struct BitWiseXorableTag, fluent::BitWiseXorable>;
+    constexpr BitWiseXorableType s1(2);
+    constexpr BitWiseXorableType s2(64);
+    static_assert((s1 ^ s2).get() == (2 ^ 64), "BitWiseXorable is not constexpr");
 }
 
 TEST_CASE("BitWiseLeftShiftable")
@@ -247,6 +352,15 @@ TEST_CASE("BitWiseLeftShiftable")
     CHECK(s1.get() == (2 << 3));
 }
 
+TEST_CASE("BitWiseLeftShiftable constexpr")
+{
+    using BitWiseLeftShiftableType =
+        fluent::NamedType<int, struct BitWiseLeftShiftableTag, fluent::BitWiseLeftShiftable>;
+    constexpr BitWiseLeftShiftableType s1(2);
+    constexpr BitWiseLeftShiftableType s2(3);
+    static_assert((s1 << s2).get() == (2 << 3), "BitWiseLeftShiftable is not constexpr");
+}
+
 TEST_CASE("BitWiseRightShiftable")
 {
     using BitWiseRightShiftableType =
@@ -256,6 +370,15 @@ TEST_CASE("BitWiseRightShiftable")
     CHECK((s1 >> s2).get() == (2 >> 3));
     s1 >>= s2;
     CHECK(s1.get() == (2 >> 3));
+}
+
+TEST_CASE("BitWiseRightShiftable constexpr")
+{
+    using BitWiseRightShiftableType =
+        fluent::NamedType<int, struct BitWiseRightShiftableTag, fluent::BitWiseRightShiftable>;
+    constexpr BitWiseRightShiftableType s1(2);
+    constexpr BitWiseRightShiftableType s2(3);
+    static_assert((s1 >> s2).get() == (2 >> 3), "BitWiseRightShiftable is not constexpr");
 }
 
 TEST_CASE("Comparable")
@@ -615,6 +738,14 @@ TEST_CASE("Dereferencable")
         int value = functionTakingInt( *functionReturningStrongInt() );
         CHECK( value == 28 );
     }
+}
+
+TEST_CASE("Dereferencable constexpr")
+{
+    using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::Dereferencable>;
+
+    constexpr StrongInt a{28};
+    static_assert( *a, "Dereferencable is not constexpr");
 }
 
 TEST_CASE("PreIncrementable")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -153,8 +153,17 @@ TEST_CASE("BinaryAddable constexpr")
     constexpr BinaryAddableType s1(12);
     constexpr BinaryAddableType s2(10);
     static_assert((s1 + s2).get() == 22, "BinaryAddable is not constexpr");
+}
+
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("BinaryAddable constexpr C++17")
+{
+    using BinaryAddableType = fluent::NamedType<int, struct BinaryAddableTag, fluent::BinaryAddable>;
+    constexpr BinaryAddableType s1(12);
+    constexpr BinaryAddableType s2(10);
     static_assert(BinaryAddableType{12}.operator+=( s2 ).get() == 22, "BinaryAddable is not constexpr");
 }
+#endif
 
 TEST_CASE("UnaryAddable")
 {
@@ -202,8 +211,16 @@ TEST_CASE("BinarySubtractable constexpr")
     constexpr BinarySubtractableType s1(12);
     constexpr BinarySubtractableType s2(10);
     static_assert((s1 - s2).get() == 2, "BinarySubtractable is not constexpr");
+}
+
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("BinarySubtractable constexpr C++17")
+{
+    using BinarySubtractableType = fluent::NamedType<int, struct BinarySubtractableTag, fluent::BinarySubtractable>;
+    constexpr BinarySubtractableType s2(10);
     static_assert(BinarySubtractableType{12}.operator-=( s2 ).get() == 2, "BinarySubtractable is not constexpr");
 }
+#endif
 
 TEST_CASE("UnarySubtractable")
 {
@@ -236,8 +253,16 @@ TEST_CASE("Multiplicable constexpr")
     constexpr MultiplicableType s1(12);
     constexpr MultiplicableType s2(10);
     static_assert((s1 * s2).get() == 120, "Multiplicable is not constexpr");
+}
+
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("Multiplicable constexpr C++17")
+{
+    using MultiplicableType = fluent::NamedType<int, struct MultiplicableTag, fluent::Multiplicable>;
+    constexpr MultiplicableType s2(10);
     static_assert(MultiplicableType{12}.operator*=( s2 ).get() == 120, "Multiplicable is not constexpr");
 }
+#endif
 
 TEST_CASE("Divisible")
 {
@@ -255,9 +280,16 @@ TEST_CASE("Divisible constexpr")
     constexpr DivisibleType s1(120);
     constexpr DivisibleType s2(10);
     static_assert((s1 / s2).get() == 12, "Divisible is not constexpr");
-    static_assert(DivisibleType{120}.operator/=( s2 ).get() == 12, "Divisible is not constexpr");
 }
 
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("Divisible constexpr C++17")
+{
+    using DivisibleType = fluent::NamedType<int, struct DivisibleTag, fluent::Divisible>;
+    constexpr DivisibleType s2(10);
+    static_assert(DivisibleType{120}.operator/=( s2 ).get() == 12, "Divisible is not constexpr");
+}
+#endif
 
 TEST_CASE("Modulable")
 {
@@ -275,8 +307,16 @@ TEST_CASE("Modulable constexpr")
     constexpr ModulableType s1(5);
     constexpr ModulableType s2(2);
     static_assert((s1 % s2).get() == 1, "Modulable is not constexpr");
+}
+
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("Modulable constexpr C++17")
+{
+    using ModulableType = fluent::NamedType<int, struct ModulableTag, fluent::Modulable>;
+    constexpr ModulableType s2(2);
     static_assert(ModulableType{5}.operator%=( s2 ).get() == 1, "Modulable is not constexpr");
 }
+#endif
 
 TEST_CASE("BitWiseInvertable")
 {
@@ -308,8 +348,16 @@ TEST_CASE("BitWiseAndable constexpr")
     constexpr BitWiseAndableType s1(2);
     constexpr BitWiseAndableType s2(64);
     static_assert((s1 & s2).get() == (2 & 64), "BitWiseAndable is not constexpr");
+}
+
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("BitWiseAndable constexpr C++17")
+{
+    using BitWiseAndableType = fluent::NamedType<int, struct BitWiseAndableTag, fluent::BitWiseAndable>;
+    constexpr BitWiseAndableType s2(64);
     static_assert(BitWiseAndableType{2}.operator&=( s2 ).get() == (2 & 64), "BitWiseAndable is not constexpr");
 }
+#endif
 
 TEST_CASE("BitWiseOrable")
 {
@@ -327,8 +375,16 @@ TEST_CASE("BitWiseOrable constexpr")
     constexpr BitWiseOrableType s1(2);
     constexpr BitWiseOrableType s2(64);
     static_assert((s1 | s2).get() == (2 | 64), "BitWiseOrable is not constexpr");
+}
+
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("BitWiseOrable constexpr C++17")
+{
+    using BitWiseOrableType = fluent::NamedType<int, struct BitWiseOrableTag, fluent::BitWiseOrable>;
+    constexpr BitWiseOrableType s2(64);
     static_assert(BitWiseOrableType{2}.operator|=( s2 ).get() == (2 | 64), "BitWiseOrable is not constexpr");
 }
+#endif
 
 TEST_CASE("BitWiseXorable")
 {
@@ -346,8 +402,16 @@ TEST_CASE("BitWiseXorable constexpr")
     constexpr BitWiseXorableType s1(2);
     constexpr BitWiseXorableType s2(64);
     static_assert((s1 ^ s2).get() == 66, "BitWiseXorable is not constexpr");
+}
+
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("BitWiseXorable constexpr C++17")
+{
+    using BitWiseXorableType = fluent::NamedType<int, struct BitWiseXorableTag, fluent::BitWiseXorable>;
+    constexpr BitWiseXorableType s2(64);
     static_assert(BitWiseXorableType{2}.operator^=( s2 ).get() == 66, "BitWiseXorable is not constexpr");
 }
+#endif
 
 TEST_CASE("BitWiseLeftShiftable")
 {
@@ -367,8 +431,17 @@ TEST_CASE("BitWiseLeftShiftable constexpr")
     constexpr BitWiseLeftShiftableType s1(2);
     constexpr BitWiseLeftShiftableType s2(3);
     static_assert((s1 << s2).get() == (2 << 3), "BitWiseLeftShiftable is not constexpr");
+}
+
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("BitWiseLeftShiftable constexpr C++17")
+{
+    using BitWiseLeftShiftableType =
+        fluent::NamedType<int, struct BitWiseLeftShiftableTag, fluent::BitWiseLeftShiftable>;
+    constexpr BitWiseLeftShiftableType s2(3);
     static_assert(BitWiseLeftShiftableType{2}.operator<<=( s2 ).get() == (2 << 3 ), "BitWiseLeftShiftable is not constexpr");
 }
+#endif
 
 TEST_CASE("BitWiseRightShiftable")
 {
@@ -388,8 +461,17 @@ TEST_CASE("BitWiseRightShiftable constexpr")
     constexpr BitWiseRightShiftableType s1(2);
     constexpr BitWiseRightShiftableType s2(3);
     static_assert((s1 >> s2).get() == (2 >> 3), "BitWiseRightShiftable is not constexpr");
+}
+
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("BitWiseRightShiftable constexpr C++17")
+{
+    using BitWiseRightShiftableType =
+        fluent::NamedType<int, struct BitWiseRightShiftableTag, fluent::BitWiseRightShiftable>;
+    constexpr BitWiseRightShiftableType s2(3);
     static_assert(BitWiseRightShiftableType{2}.operator>>=( s2 ).get() == (2 >> 3 ), "BitWiseRightShiftable is not constexpr");
 }
+#endif
 
 TEST_CASE("Comparable")
 {
@@ -846,7 +928,7 @@ TEST_CASE("PreIncrementable")
 }
 
 #if FLUENT_CPP17_PRESENT
-TEST_CASE("PreIncrementable constexpr")
+TEST_CASE("PreIncrementable constexpr C++17")
 {
     using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PreIncrementable>;
     static_assert( (++StrongInt{1}).get() == 2, "PreIncrementable is not constexpr");
@@ -863,7 +945,7 @@ TEST_CASE("PostIncrementable")
 }
 
 #if FLUENT_CPP17_PRESENT
-TEST_CASE("PostIncrementable constexpr")
+TEST_CASE("PostIncrementable constexpr C++17")
 {
     using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PostIncrementable>;
     static_assert( (StrongInt{1}++).get() == 1, "PostIncrementable is not constexpr");
@@ -880,7 +962,7 @@ TEST_CASE("PreDecrementable")
 }
 
 #if FLUENT_CPP17_PRESENT
-TEST_CASE("PreDecrementable constexpr")
+TEST_CASE("PreDecrementable constexpr C++17")
 {
     using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PreDecrementable>;
     static_assert( (--StrongInt{1}).get() == 0, "PreDecrementable is not constexpr");
@@ -897,7 +979,7 @@ TEST_CASE("PostDecrementable")
 }
 
 #if FLUENT_CPP17_PRESENT
-TEST_CASE("PostDecrementable constexpr")
+TEST_CASE("PostDecrementable constexpr C++17")
 {
     using StrongInt = fluent::NamedType<int, struct StrongIntTag, fluent::PostDecrementable>;
     static_assert( (StrongInt{1}--).get() == 1, "PostDecrementable is not constexpr");

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -710,7 +710,8 @@ TEST_CASE("Method callable")
     REQUIRE(constStrongA->constMethod() == 42);
 }
 
-TEST_CASE("Method callable constexpr")
+#if FLUENT_CPP17_PRESENT
+TEST_CASE("Method callable constexpr C++17")
 {
     class A
     {
@@ -739,6 +740,7 @@ TEST_CASE("Method callable constexpr")
     static_assert( StrongA(A(42))->method() == 42, "MethodCallable is not constexpr");
     static_assert(constStrongA->constMethod() == 42, "MethodCallable is not constexpr");
 }
+#endif
 
 TEST_CASE("Callable")
 {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -708,7 +708,7 @@ constexpr bool operator==(testFunctionCallable_B const& a1, testFunctionCallable
 constexpr int functionTakingB(testFunctionCallable_B const& b)
 {
     return b.x;
-};
+}
 
 TEST_CASE("Function callable constexpr")
 {


### PR DESCRIPTION
Summary of the proposed changes:

- Make ostream operator<< enabled only if the skill Printable is present
  - operator<< is currently always defined for all types. This may have side effects in some cases, like using Boost.Test. It should be generated only when using the Printable skill.
  - It is now enabled only when the Printable skill is set.
  - Added a unit test.
- Add skill Dereferencable (#52)
- Added tests for PreIncrementable, PostIncrementable, PostIncrementable
  - Also fixed compilation for at least MSVC for PostIncrementable and PostDecrementable skills
- Added constexpr for all skills
-   Some operators are only constexpr under C++17 and over
- Adding support for [[nodiscard]] if available

Travis CI is ok, and works well on MSVC