### PR TITLE
Make `NamedType` trivially constructible when the underlying type is

### DIFF
--- a/include/NamedType/named_type_impl.hpp
+++ b/include/NamedType/named_type_impl.hpp
@@ -54,10 +54,7 @@ public:
     using UnderlyingType = T;
 
     // constructor
-    template <typename T_ = T, typename = std::enable_if<std::is_default_constructible<T>::value, void>>
-    constexpr NamedType() noexcept(std::is_nothrow_constructible<T>::value) : value_()
-    {
-    }
+    NamedType()  = default;
 
     explicit constexpr NamedType(T const& value) noexcept(std::is_nothrow_copy_constructible<T>::value) : value_(value)
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,12 +45,18 @@ else()
 		-Wzero-as-null-pointer-constant
 		-Wfloat-equal
 		-Wshadow
-		-Weffc++
         $<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>
         $<$<CXX_COMPILER_ID:GNU>:-Wnoexcept>
         $<$<CXX_COMPILER_ID:GNU>:-Wstrict-null-sentinel>
         $<$<CXX_COMPILER_ID:GNU>:-Wuseless-cast>
 	)
+	set(OLD_GNU FALSE)
+	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7)
+		set(OLD_GNU TRUE)
+	endif()
+	if (NOT ${OLD_GNU})
+		target_compile_options(${PROJECT_NAME} PRIVATE -Weffc++)
+	endif()
 endif()
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -99,12 +100,19 @@ TEST_CASE("Implicit conversion of NamedType to NamedType::ref")
     REQUIRE(j.get() == 43);
 }
 
+struct PotentiallyThrowing
+{
+    PotentiallyThrowing(){}
+};
 TEST_CASE("Default construction")
 {
     using StrongInt = fluent::NamedType<int, struct StrongIntTag>;
     StrongInt strongInt;
     strongInt.get() = 42;
     REQUIRE(strongInt.get() == 42);
+    static_assert(std::is_nothrow_constructible<StrongInt>::value, "StrongInt is not nothrow constructible");
+    using StrongPotentiallyThrowing = fluent::NamedType<PotentiallyThrowing, struct  StrongPotentiallyThrowingTag>;
+    static_assert(!std::is_nothrow_constructible<StrongPotentiallyThrowing>::value, "StrongPotentiallyThrowing is nothrow constructible");
 }
 
 template<typename Function>

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -104,12 +104,37 @@ struct PotentiallyThrowing
 {
     PotentiallyThrowing(){}
 };
+
+struct NonDefaultConstructible
+{
+    NonDefaultConstructible(int){}
+};
+
+struct UserProvided
+{
+    UserProvided();
+};
+UserProvided::UserProvided() = default;
+
 TEST_CASE("Default construction")
 {
     using StrongInt = fluent::NamedType<int, struct StrongIntTag>;
     StrongInt strongInt;
     strongInt.get() = 42;
     REQUIRE(strongInt.get() == 42);
+    static_assert(std::is_nothrow_constructible<StrongInt>::value, "StrongInt is not nothrow constructible");
+
+    //Default constructible
+    static_assert(std::is_default_constructible<StrongInt>::value, "StrongInt is not default constructible");
+    using StrongNonDefaultConstructible = fluent::NamedType<NonDefaultConstructible, struct  StrongNonDefaultConstructibleTag>;
+    static_assert(!std::is_default_constructible<StrongNonDefaultConstructible>::value, "StrongNonDefaultConstructible is default constructible");
+
+    //Trivially constructible
+    static_assert(std::is_trivially_constructible<StrongInt>::value, "StrongInt is not trivially constructible");
+    using StrongUserProvided = fluent::NamedType<UserProvided, struct  StrongUserProvidedTag>;
+    static_assert(!std::is_trivially_constructible<StrongUserProvided>::value, "StrongUserProvided is trivially constructible");
+
+    //Nothrow constructible
     static_assert(std::is_nothrow_constructible<StrongInt>::value, "StrongInt is not nothrow constructible");
     using StrongPotentiallyThrowing = fluent::NamedType<PotentiallyThrowing, struct  StrongPotentiallyThrowingTag>;
     static_assert(!std::is_nothrow_constructible<StrongPotentiallyThrowing>::value, "StrongPotentiallyThrowing is nothrow constructible");


### PR DESCRIPTION
This makes `NamedType` trivially constructible when the underlying type is. It also adds some useful assertions in the tests.

See the individual commit messages for detailed descriptions.