### PR TITLE
Make `Comparable`'s operators symmetric, fixing C++20 diagnostics

### DIFF
--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -259,36 +259,27 @@ struct BitWiseRightShiftable : crtp<T, BitWiseRightShiftable>
 template <typename T>
 struct Comparable : crtp<T, Comparable>
 {
-    FLUENT_NODISCARD constexpr bool operator<(T const& other) const
+    FLUENT_NODISCARD constexpr bool operator<(Comparable<T> const& other) const
     {
-        return this->underlying().get() < other.get();
+        return this->underlying().get() < other.underlying().get();
     }
-    FLUENT_NODISCARD constexpr bool operator>(T const& other) const
+    FLUENT_NODISCARD constexpr bool operator>(Comparable<T> const& other) const
     {
-        return other.get() < this->underlying().get();
+        return other.underlying().get() < this->underlying().get();
     }
-    FLUENT_NODISCARD constexpr bool operator<=(T const& other) const
+    FLUENT_NODISCARD constexpr bool operator<=(Comparable<T> const& other) const
     {
-        return !(other.get() < this->underlying().get());
+        return !(other < *this);
     }
-    FLUENT_NODISCARD constexpr bool operator>=(T const& other) const
+    FLUENT_NODISCARD constexpr bool operator>=(Comparable<T> const& other) const
     {
         return !(*this < other);
     }
-// On Visual Studio before 19.22, you cannot define constexpr with friend function
-// See: https://stackoverflow.com/a/60400110
-#if defined(_MSC_VER) && _MSC_VER < 1922
-    FLUENT_NODISCARD constexpr bool operator==(T const& other) const
+    FLUENT_NODISCARD constexpr bool operator==(Comparable<T> const& other) const
     {
-        return !(*this < other) && !(other.get() < this->underlying().get());
+        return !(*this < other) && !(other < *this);
     }
-#else
-    FLUENT_NODISCARD friend constexpr bool operator==(Comparable<T> const& self, T const& other)
-    {
-        return !(self < other) && !(other.get() < self.underlying().get());
-    }
-#endif
-    FLUENT_NODISCARD constexpr bool operator!=(T const& other) const
+    FLUENT_NODISCARD constexpr bool operator!=(Comparable<T> const& other) const
     {
         return !(*this == other);
     }


### PR DESCRIPTION
When C++20 is enabled, this fixes a warning when compiling `==` or `!=` under Clang, and an error when compiling `!=` under MSVC or GCC. (See https://godbolt.org/z/Th4WE4EdP for an example of this error and warning.)

C++20 can now rewrite comparison operators, potentially swapping arguments or rewriting missing operators in terms of other operators. As `NamedType`s inheriting from the `Comparable` skill fulfil both sides of the comparisons, this can lead to ambiguities as to which comparison operator should be selected, once swapped arguments are considered.

This PR fixes this ambiguity by making the comparisons take two `Comparable<T>`s instead of a `Comparable<T>` and a `T`.

If there's a reason for this asymmetry, then I'm happy for a different solution to be used here. I've also effectively reverted bcc4051 (as this seemed to be part of the reason why MSVC and GCC considered `!=` ambiguous enough to be an error), so if this reintroduces a warning, then also let me know.