### PR TITLE
Added EqualityComparable skill

### DIFF
--- a/include/NamedType/underlying_functionalities.hpp
+++ b/include/NamedType/underlying_functionalities.hpp
@@ -285,6 +285,19 @@ struct Comparable : crtp<T, Comparable>
     }
 };
 
+template <typename T>
+struct EqualityComparable : crtp<T, EqualityComparable>
+{
+    FLUENT_NODISCARD constexpr bool operator==(EqualityComparable<T> const& other) const
+    {
+        return this->underlying().get() == other.underlying().get();
+    }
+    FLUENT_NODISCARD constexpr bool operator!=(EqualityComparable<T> const& other) const
+    {
+        return !(*this == other);
+    }
+};
+
 template< typename T >
 struct Dereferencable;
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -541,6 +541,15 @@ TEST_CASE("Comparable constexpr")
     static_assert(!(9_meter >= 10_meter), "Comparable is not constexpr");
 }
 
+TEST_CASE("EqualityComparable")
+{
+    using Name = fluent::NamedType<std::string, struct NameParameter, fluent::EqualityComparable>;
+    REQUIRE((Name("Bob") == Name("Bob")));
+    REQUIRE(!(Name("Bob") == Name("Alice")));
+    REQUIRE((Name("Bob") != Name("Alice")));
+    REQUIRE(!(Name("Bob") != Name("Bob")));
+}
+
 TEST_CASE("ConvertibleWithOperator")
 {
     struct B


### PR DESCRIPTION
It often makes sense for type to be equality comparable but not comparable. This skill has been for a quite some time in a fork of NamedType library we use internally at my company.
Naming inspired by https://en.cppreference.com/w/cpp/concepts/equality_comparable.